### PR TITLE
Fix end index in buffer range from LZ4/Streams.swift

### DIFF
--- a/Sources/LZ4/Streams.swift
+++ b/Sources/LZ4/Streams.swift
@@ -58,7 +58,8 @@ public class BufferedMemoryStream: BidirectionalStream, Equatable, GreedyStream 
         }
 
         let maxTransferrable = min(size - readerIndex, length)
-        internalRepresentation.copyBytes(to: buffer, from: readerIndex..<maxTransferrable)
+        let readerLastIndex  = readerIndex + maxTransferrable
+        internalRepresentation.copyBytes(to: buffer, from: readerIndex..<readerLastIndex)
         readerIndex += maxTransferrable
 
         return maxTransferrable


### PR DESCRIPTION
@m0wfo The problem is not with the calls to LZ4 library. I cheked interoperability between Swift and LZ4 C project, and it works correctly.

The problem is not with the decompression. I also checked compression, and it seems that current implementation of compression for Swift <-> LZ4 works without issues.

I found that we have a problem with *compression data values passed through arguments to LZ4 function* `LZ4F_decompress()` when `NIOExtensions` is used. Therefore, **we get decompression data invalid because of providing invalid compression data**.

It's pure issue in the Swift code of this project.

* * *

I started to check how compressed data is being prepared and where it gets wrong on the way to LZ4 `LZ4F_decompress()`. I found that `Data()` object from `LZ4/Streams.swift` is correct, and it contains valid memory buffers. This is being confirmed by `readAll()` method that works as expected.

The last point was to check `read()` method which is definetely used in frame decompression via stream.

I detected that buffer from stream is not prepared correctly in `read()` method. There is use of byte range defined by start and end indexes. Start index is correct. But the end index in the code is actually not an index, but a number of bytes to be used in the buffer. Correct approach is to use end index as `number of bytes + start index`.

It will make correct end index, and this patch solves this problem and fixes the failed test.